### PR TITLE
fix(deps): migrate from uni-time to iso-time and pin versions

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -358,12 +358,6 @@
             "command": "./node_modules/.bin/rhachet roles boot --repo ehmpathy --role ergonomist",
             "timeout": 60,
             "author": "repo=ehmpathy/role=ergonomist"
-          },
-          {
-            "type": "command",
-            "command": "./node_modules/.bin/rhachet roles boot --role librarian",
-            "timeout": 30,
-            "author": "repo=bhrain/role=librarian"
           }
         ]
       },

--- a/package.json
+++ b/package.json
@@ -64,14 +64,14 @@
     "upgrade:rhachet": "rhachet upgrade"
   },
   "dependencies": {
-    "@ehmpathy/uni-time": "^1.7.4",
-    "domain-objects": "0.31.12",
+    "iso-time": "1.11.7",
+    "domain-objects": "0.31.13",
     "helpful-errors": "1.7.3",
-    "procedure-fns": "^1.0.1",
-    "serde-fns": "^1.3.1",
-    "simple-in-memory-cache": "^0.4.0",
-    "simple-on-disk-cache": "1.7.9",
-    "type-fns": "1.21.2"
+    "procedure-fns": "1.0.1",
+    "serde-fns": "1.3.1",
+    "simple-in-memory-cache": "0.4.2",
+    "simple-on-disk-cache": "1.7.10",
+    "type-fns": "1.21.3"
   },
   "devDependencies": {
     "@biomejs/biome": "2.3.8",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,30 +8,30 @@ importers:
 
   .:
     dependencies:
-      '@ehmpathy/uni-time':
-        specifier: ^1.7.4
-        version: 1.9.1
       domain-objects:
-        specifier: 0.31.12
-        version: 0.31.12
+        specifier: 0.31.13
+        version: 0.31.13
       helpful-errors:
         specifier: 1.7.3
         version: 1.7.3
+      iso-time:
+        specifier: 1.11.7
+        version: 1.11.7
       procedure-fns:
-        specifier: ^1.0.1
+        specifier: 1.0.1
         version: 1.0.1
       serde-fns:
-        specifier: ^1.3.1
+        specifier: 1.3.1
         version: 1.3.1
       simple-in-memory-cache:
-        specifier: ^0.4.0
-        version: 0.4.0
+        specifier: 0.4.2
+        version: 0.4.2
       simple-on-disk-cache:
-        specifier: 1.7.9
-        version: 1.7.9
+        specifier: 1.7.10
+        version: 1.7.10
       type-fns:
-        specifier: 1.21.2
-        version: 1.21.2
+        specifier: 1.21.3
+        version: 1.21.3
     devDependencies:
       '@biomejs/biome':
         specifier: 2.3.8
@@ -74,7 +74,7 @@ importers:
         version: 0.47.72(declapract@0.13.21)
       declastruct:
         specifier: 1.9.1
-        version: 1.9.1(domain-objects@0.31.12)
+        version: 1.9.1(domain-objects@0.31.13)
       declastruct-github:
         specifier: 1.4.0
         version: 1.4.0
@@ -2979,8 +2979,8 @@ packages:
     resolution: {integrity: sha512-jRHVFk8ZM1ObkSBtSM5QrygqWOBh66dBZm4iuFGdTGv3gotPvBZKASe3eXSBdBWXsL+ahdF2h+OdqD0IAnJVcg==}
     engines: {node: '>=8.0.0'}
 
-  domain-objects@0.31.12:
-    resolution: {integrity: sha512-LX5gAC+xweKSmvBNT6HMDIjH+3pi45MNFL1WQovp3kXagzgxFlcDXdXJ1V82kfoB4va6atjgYkVGERrt+prIPA==}
+  domain-objects@0.31.13:
+    resolution: {integrity: sha512-6i4w5gIV6lgOw9uEzETYW9Ejbm7H1OyQAwjE5zX6yPxUyTXT9CYAmrRuAIEmX83hy+YfK7gsh+6+6Ew7vKOCDA==}
     engines: {node: '>=8.0.0'}
 
   domain-objects@0.31.3:
@@ -4631,6 +4631,10 @@ packages:
     resolution: {integrity: sha512-FizjX3DqiWquodrMGgdpo7GBk9x745e/haifLJper3k1sC4Y9pibn8ysKgcfCtQNtga7V/HDsKNYnP6qyFW8rw==}
     engines: {node: '>=8.0.0'}
 
+  simple-in-memory-cache@0.4.2:
+    resolution: {integrity: sha512-NJw/bOHh1LtD7z4eSR4DIepppfMe5GizfVGrxuHaCa+sR/pDtGT28dsvX7KpH2dCMl29HCgYK1ITr8BAGFUXEA==}
+    engines: {node: '>=8.0.0'}
+
   simple-log-methods@0.6.1:
     resolution: {integrity: sha512-POHiGnZqnQSivzgSDJfVE3/GAVPUEG0zc5vRLKIPpTnIQ6IY0QhOJOO3Ur0rKgXzwU/hlYpqabkELR62CauMhA==}
     engines: {node: '>=8.0.0'}
@@ -4647,12 +4651,12 @@ packages:
     resolution: {integrity: sha512-VeI9erbjgKtZ8bwdpHqkqgZomVqchZHFWidN3/5Jmb6UcKHKdduiADPAVqIwvFmobFOEtIyybyVw5bEaZpKODw==}
     engines: {node: '>=8.0.0'}
 
-  simple-on-disk-cache@1.7.3:
-    resolution: {integrity: sha512-N5ILAhtiYSLVL2UyzVFfzcd/nWzgxPS/ksSYwUChDGS4HwKh6QR+18QwUtQ78oV/QXGDiXrtuNQxdTbwYrkfcw==}
+  simple-on-disk-cache@1.7.10:
+    resolution: {integrity: sha512-z/uFEnbxblAa0j3PmEwEZyKV73YwEG0vEgcFkjy4ppjlPhaL5oi6G5DvoBua5aFYEp8kjDOy4OpLPux4J6PWqA==}
     engines: {node: '>=8.0.0'}
 
-  simple-on-disk-cache@1.7.9:
-    resolution: {integrity: sha512-JxQNYS+0AnXdECLW2LKOEBoUFL8wDQKLEaazB7xSO8m2HXj7CEKmaAYCXZ6ads/aNiZVo5ETg58Z45ZTRN+ROw==}
+  simple-on-disk-cache@1.7.3:
+    resolution: {integrity: sha512-N5ILAhtiYSLVL2UyzVFfzcd/nWzgxPS/ksSYwUChDGS4HwKh6QR+18QwUtQ78oV/QXGDiXrtuNQxdTbwYrkfcw==}
     engines: {node: '>=8.0.0'}
 
   slash@3.0.0:
@@ -4902,6 +4906,10 @@ packages:
 
   type-fns@1.21.2:
     resolution: {integrity: sha512-9/E7WpYVjJxIisH2lSpHnqwetk6SxVx2M+EI1dv0SMp3ztB6Qg4zrYwURepJHyt/zNRTb7XoGoo1H5Bxq9wI5Q==}
+    engines: {node: '>=8.0.0'}
+
+  type-fns@1.21.3:
+    resolution: {integrity: sha512-aB66HI+uWPsU/XuCHUY2ShCdnNVyDQT2F3OSc2AyezMqQSIC9ww8UsnGFxvfAh54ku5PL4gHtBMueGWanbkSAA==}
     engines: {node: '>=8.0.0'}
 
   typescript@5.4.5:
@@ -8537,12 +8545,12 @@ snapshots:
       visualogic: 1.3.2
       with-simple-cache: 0.15.1
 
-  declastruct@1.9.1(domain-objects@0.31.12):
+  declastruct@1.9.1(domain-objects@0.31.13):
     dependencies:
       bottleneck: 2.19.5
       chalk: 5.4.1
       commander: 14.0.2
-      domain-objects: 0.31.12
+      domain-objects: 0.31.13
       helpful-errors: 1.5.3
       jest-diff: 30.0.2
       rhachet-artifact-git: 1.1.3
@@ -8638,7 +8646,7 @@ snapshots:
       '@types/yup': 0.29.14
       change-case: 4.1.2
       cross-sha256: 1.2.0
-      type-fns: 1.21.2
+      type-fns: 1.21.3
 
   domain-objects@0.31.0:
     dependencies:
@@ -8647,7 +8655,7 @@ snapshots:
       change-case: 4.1.2
       cross-sha256: 1.2.0
       helpful-errors: 1.7.3
-      type-fns: 1.21.2
+      type-fns: 1.21.3
 
   domain-objects@0.31.10:
     dependencies:
@@ -8663,7 +8671,7 @@ snapshots:
       type-fns: 1.21.2
       uuid-fns: 1.1.3
 
-  domain-objects@0.31.12:
+  domain-objects@0.31.13:
     dependencies:
       change-case: 4.1.2
       helpful-errors: 1.7.3
@@ -10694,12 +10702,19 @@ snapshots:
     dependencies:
       '@ehmpathy/uni-time': 1.9.1
 
+  simple-in-memory-cache@0.4.2:
+    dependencies:
+      domain-objects: 0.31.9
+      helpful-errors: 1.7.3
+      iso-time: 1.11.7
+      type-fns: 1.21.2
+
   simple-log-methods@0.6.1:
     dependencies:
       '@ehmpathy/error-fns': 1.3.7
       '@ehmpathy/uni-time': 1.9.1
       domain-glossary-procedure: 1.0.0
-      type-fns: 1.21.2
+      type-fns: 1.21.3
 
   simple-log-methods@0.6.12:
     dependencies:
@@ -10715,7 +10730,7 @@ snapshots:
       '@ehmpathy/error-fns': 1.3.7
       '@ehmpathy/uni-time': 1.9.1
       domain-glossary-procedure: 1.0.0
-      type-fns: 1.21.2
+      type-fns: 1.21.3
 
   simple-log-methods@0.6.9:
     dependencies:
@@ -10726,6 +10741,17 @@ snapshots:
       iso-time: 1.11.7
       type-fns: 1.21.0
 
+  simple-on-disk-cache@1.7.10:
+    dependencies:
+      domain-objects: 0.31.13
+      hash-fns: 1.1.0
+      helpful-errors: 1.7.3
+      iso-time: 1.11.7
+      serde-fns: 1.3.1
+      simple-in-memory-cache: 0.4.2
+      type-fns: 1.21.2
+      with-bottleneck: 0.1.1
+
   simple-on-disk-cache@1.7.3:
     dependencies:
       '@aws-sdk/client-s3': 3.954.0
@@ -10735,21 +10761,10 @@ snapshots:
       hash-fns: 1.1.0
       helpful-errors: 1.5.3
       serde-fns: 1.3.1
-      simple-in-memory-cache: 0.4.0
+      simple-in-memory-cache: 0.4.2
       type-fns: 1.21.0
     transitivePeerDependencies:
       - aws-crt
-
-  simple-on-disk-cache@1.7.9:
-    dependencies:
-      '@ehmpathy/uni-time': 1.9.1
-      domain-objects: 0.31.9
-      hash-fns: 1.1.0
-      helpful-errors: 1.7.3
-      serde-fns: 1.3.1
-      simple-in-memory-cache: 0.4.0
-      type-fns: 1.21.2
-      with-bottleneck: 0.1.1
 
   slash@3.0.0: {}
 
@@ -11031,6 +11046,11 @@ snapshots:
       domain-objects: 0.31.10
       helpful-errors: 1.7.3
 
+  type-fns@1.21.3:
+    dependencies:
+      domain-objects: 0.31.10
+      helpful-errors: 1.7.3
+
   typescript@5.4.5: {}
 
   typescript@5.9.3: {}
@@ -11164,9 +11184,9 @@ snapshots:
       '@ehmpathy/uni-time': 1.9.1
       procedure-fns: 1.0.1
       serde-fns: 1.3.1
-      simple-in-memory-cache: 0.4.0
-      simple-on-disk-cache: 1.7.9
-      type-fns: 1.21.2
+      simple-in-memory-cache: 0.4.2
+      simple-on-disk-cache: 1.7.10
+      type-fns: 1.21.3
 
   with-simple-cache@0.15.3(@huggingface/transformers@4.2.0)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@22.15.21)(zod@4.3.4):
     dependencies:
@@ -11175,8 +11195,8 @@ snapshots:
       helpful-errors: 1.5.3
       procedure-fns: 1.0.1
       serde-fns: 1.3.1
-      simple-in-memory-cache: 0.4.0
-      simple-on-disk-cache: 1.7.9
+      simple-in-memory-cache: 0.4.2
+      simple-on-disk-cache: 1.7.10
       type-fns: 1.21.0
     transitivePeerDependencies:
       - '@huggingface/transformers'
@@ -11190,9 +11210,9 @@ snapshots:
     dependencies:
       '@ehmpathy/uni-time': 1.9.1
       serde-fns: 1.3.1
-      simple-in-memory-cache: 0.4.0
-      simple-on-disk-cache: 1.7.9
-      type-fns: 1.21.2
+      simple-in-memory-cache: 0.4.2
+      simple-on-disk-cache: 1.7.10
+      type-fns: 1.21.3
       visualogic: 1.3.3
 
   with-simple-caching@0.14.4:
@@ -11200,9 +11220,9 @@ snapshots:
       '@ehmpathy/uni-time': 1.9.1
       procedure-fns: 1.0.1
       serde-fns: 1.3.1
-      simple-in-memory-cache: 0.4.0
-      simple-on-disk-cache: 1.7.9
-      type-fns: 1.21.2
+      simple-in-memory-cache: 0.4.2
+      simple-on-disk-cache: 1.7.10
+      type-fns: 1.21.3
 
   word-wrap@1.2.5: {}
 

--- a/src/.test.assets/createExampleCache.ts
+++ b/src/.test.assets/createExampleCache.ts
@@ -1,4 +1,4 @@
-import { UniDuration } from '@ehmpathy/uni-time';
+import { IsoDuration } from 'iso-time';
 
 import { SimpleAsyncCache, SimpleSyncCache } from '@src/domain.objects/SimpleCache';
 
@@ -8,7 +8,7 @@ export const createExampleSyncCache = () => {
     set: (
       key: string,
       value: any,
-      options?: { expiration?: UniDuration | null },
+      options?: { expiration?: IsoDuration | null },
     ) => {
       store[key] = options ? { value, options } : { value };
     },
@@ -23,7 +23,7 @@ export const createExampleAsyncCache = <T>() => {
     set: async (
       key: string,
       value: T | undefined,
-      options?: { expiration?: UniDuration | null },
+      options?: { expiration?: IsoDuration | null },
     ) => {
       // eslint-disable-next-line no-nested-ternary
       store[key] =
@@ -47,7 +47,7 @@ export const createExampleSyncCacheWithUri = <T>(baseUri: string) => {
     set: (
       key: string,
       value: T | undefined,
-      options?: { expiration?: UniDuration | null },
+      options?: { expiration?: IsoDuration | null },
     ) => {
       // eslint-disable-next-line no-nested-ternary
       store[key] =
@@ -72,7 +72,7 @@ export const createExampleSyncCacheWithoutUri = <T>() => {
     set: (
       key: string,
       value: T | undefined,
-      options?: { expiration?: UniDuration | null },
+      options?: { expiration?: IsoDuration | null },
     ) => {
       // eslint-disable-next-line no-nested-ternary
       store[key] =
@@ -96,7 +96,7 @@ export const createExampleAsyncCacheWithUri = <T>(baseUri: string) => {
     set: async (
       key: string,
       value: T | undefined,
-      options?: { expiration?: UniDuration | null },
+      options?: { expiration?: IsoDuration | null },
     ) => {
       // eslint-disable-next-line no-nested-ternary
       store[key] =
@@ -121,7 +121,7 @@ export const createExampleAsyncCacheWithoutUri = <T>() => {
     set: async (
       key: string,
       value: T | undefined,
-      options?: { expiration?: UniDuration | null },
+      options?: { expiration?: IsoDuration | null },
     ) => {
       // eslint-disable-next-line no-nested-ternary
       store[key] =

--- a/src/domain.objects/SimpleCache.ts
+++ b/src/domain.objects/SimpleCache.ts
@@ -1,4 +1,4 @@
-import type { UniDuration } from '@ehmpathy/uni-time';
+import type { IsoDuration } from 'iso-time';
 
 /**
  * a simple cache which synchronously gets and sets values to its store
@@ -8,7 +8,7 @@ export interface SimpleSyncCache<T> {
   set: (
     key: string,
     value: T | undefined,
-    options?: { expiration?: UniDuration | null },
+    options?: { expiration?: IsoDuration | null },
   ) => void;
 }
 
@@ -20,7 +20,7 @@ export interface SimpleAsyncCache<T> {
   set: (
     key: string,
     value: T | undefined,
-    options?: { expiration?: UniDuration | null },
+    options?: { expiration?: IsoDuration | null },
   ) => Promise<void>;
 }
 

--- a/src/domain.operations/wrappers/withSimpleCache.scope=expiration.test.ts
+++ b/src/domain.operations/wrappers/withSimpleCache.scope=expiration.test.ts
@@ -5,12 +5,12 @@ import { withSimpleCache } from './withSimpleCache';
 /**
  * type tests for expiration option type
  *
- * verifies expiration accepts UniDuration or null
+ * verifies expiration accepts IsoDuration or null
  *
  * symmetric with withSimpleCacheAsync.expiration.type.test.ts per rule.require.wrapper-symmetry
  */
 describe('withSimpleCache.expiration.types', () => {
-  it('accepts UniDuration with seconds', () => {
+  it('accepts IsoDuration with seconds', () => {
     const cache: SimpleCache<number> = {
       get: () => 42,
       set: () => {},
@@ -22,7 +22,7 @@ describe('withSimpleCache.expiration.types', () => {
     });
   });
 
-  it('accepts UniDuration with minutes', () => {
+  it('accepts IsoDuration with minutes', () => {
     const cache: SimpleCache<number> = {
       get: () => 42,
       set: () => {},
@@ -34,7 +34,7 @@ describe('withSimpleCache.expiration.types', () => {
     });
   });
 
-  it('accepts UniDuration with hours', () => {
+  it('accepts IsoDuration with hours', () => {
     const cache: SimpleCache<number> = {
       get: () => 42,
       set: () => {},

--- a/src/domain.operations/wrappers/withSimpleCache.ts
+++ b/src/domain.operations/wrappers/withSimpleCache.ts
@@ -1,5 +1,5 @@
-import type { UniDuration } from '@ehmpathy/uni-time';
 import { UnexpectedCodePathError } from 'helpful-errors';
+import type { IsoDuration } from 'iso-time';
 import { isNotUndefined, type NotUndefined } from 'type-fns';
 
 import type { HasCacheUri, SimpleCache } from '@src/domain.objects/SimpleCache';
@@ -121,7 +121,7 @@ export interface WithSimpleCacheOptions<
    *
    * @default undefined (cache decides)
    */
-  expiration?: UniDuration | null;
+  expiration?: IsoDuration | null;
 
   /**
    * whether to bypass the cache for get or set operations

--- a/src/domain.operations/wrappers/withSimpleCacheAsync.scope=expiration.test.ts
+++ b/src/domain.operations/wrappers/withSimpleCacheAsync.scope=expiration.test.ts
@@ -5,12 +5,12 @@ import { withSimpleCacheAsync } from './withSimpleCacheAsync';
 /**
  * type tests for expiration option type
  *
- * verifies expiration accepts UniDuration or null
+ * verifies expiration accepts IsoDuration or null
  *
  * symmetric with withSimpleCache.expiration.type.test.ts per rule.require.wrapper-symmetry
  */
 describe('withSimpleCacheAsync.expiration.types', () => {
-  it('accepts UniDuration with seconds', () => {
+  it('accepts IsoDuration with seconds', () => {
     const cache: SimpleCache<number> = {
       get: async () => 42,
       set: async () => {},
@@ -25,7 +25,7 @@ describe('withSimpleCacheAsync.expiration.types', () => {
     );
   });
 
-  it('accepts UniDuration with minutes', () => {
+  it('accepts IsoDuration with minutes', () => {
     const cache: SimpleCache<number> = {
       get: async () => 42,
       set: async () => {},
@@ -40,7 +40,7 @@ describe('withSimpleCacheAsync.expiration.types', () => {
     );
   });
 
-  it('accepts UniDuration with hours', () => {
+  it('accepts IsoDuration with hours', () => {
     const cache: SimpleCache<number> = {
       get: async () => 42,
       set: async () => {},

--- a/src/domain.operations/wrappers/withSimpleCacheAsync.ts
+++ b/src/domain.operations/wrappers/withSimpleCacheAsync.ts
@@ -1,5 +1,5 @@
-import type { UniDuration } from '@ehmpathy/uni-time';
 import { UnexpectedCodePathError } from 'helpful-errors';
+import type { IsoDuration } from 'iso-time';
 import { createCache, type SimpleInMemoryCache } from 'simple-in-memory-cache';
 import { isNotUndefined, type NotUndefined } from 'type-fns';
 
@@ -142,7 +142,7 @@ export interface WithSimpleCacheAsyncOptions<
    *
    * @default undefined (cache decides)
    */
-  expiration?: UniDuration | null;
+  expiration?: IsoDuration | null;
 
   /**
    * whether to bypass the cache for get or set operations

--- a/src/domain.operations/wrappers/withSimpleCacheOnDisk.ts
+++ b/src/domain.operations/wrappers/withSimpleCacheOnDisk.ts
@@ -1,4 +1,4 @@
-import type { UniDuration } from '@ehmpathy/uni-time';
+import type { IsoDuration } from 'iso-time';
 import type { ProcedureInput } from 'procedure-fns';
 import {
   asSerialJSON,
@@ -26,7 +26,7 @@ export const withSimpleCacheOnDisk = <
       name: string;
       version: string | null;
     };
-    expiration?: UniDuration | null;
+    expiration?: IsoDuration | null;
     directory: ProcedureInput<typeof createCache>['directory'];
   },
 ) => {


### PR DESCRIPTION
fix(deps): migrate from uni-time to iso-time and pin versions

- replace @ehmpathy/uni-time with iso-time
- rename UniDuration to IsoDuration across codebase
- pin all dependency versions (remove ^ prefixes)
- upgrade deps to latest: domain-objects, type-fns, simple-in-memory-cache, simple-on-disk-cache

---
🐢🌊 surfed in by seaturtle[bot]